### PR TITLE
Improve performance

### DIFF
--- a/math.sh
+++ b/math.sh
@@ -1,91 +1,46 @@
 
-let scale="100000000"
-let frac_digits=${#scale}
+scale="100000000"
+frac_digits=${#scale}
 
-add() {
-    local a=$1
-    local b=$2
-    echo $((a + b))
-}
-
-sub() {
-    local a=$1
-    local b=$2
-    echo $((a - b))
-}
+add() ((ret = $1 + $2, 1))
+sub() ((ret = $1 - $2, 1))
 
 mul() {
-    local a=$1
-    local b=$2
-    local res=$((a * b / scale))
-
-    if [ $res -lt 0 ] && [ $a -gt 0 ] && [ $b -gt 0 ]
-    then
-        log "OVERFLOW DETECTED: ${a} x ${b} = ${res}"
-    fi
-
-    echo $res
-}
-
-div() {
-    local a=$1
-    local b=$2
-    echo $((a * scale / b))
-}
-
-div_by_2() {
-    local a=$1
-    echo $((a >> 1))
-}
-
-
-mul_by_2() {
-    local a=$1
-    echo $((a << 1))
-}
-
-truncate() {
-    local a=$1
-    echo $((a / scale))
-}
-
-abs() {
-    local x=$1
-    if [ $x -lt 0 ]
-    then
-        echo $(( -x ))
-    else
-        echo $x
+    ((ret = $1 * $2 / scale, 1))
+    if ((ret < 0 && $1 > 0 && $2 > 0)); then
+      log "OVERFLOW DETECTED: $1 x $2 = $ret"
     fi
 }
+div() ((ret = $1 * scale / $2, 1))
 
+div_by_2() ((ret = $1 >> 1, 1))
+mul_by_2() ((ret = $1 << 1, 1))
 
+truncate() ((ret = $1 / scale, 1))
+abs() ((ret = $1 < 0 ? -$1 : $1, 1))
 sqrt() {
     local x=$1
-    if [ "$x" -lt 0 ]
-    then
+    if ((x < 0)); then
         fatal "arg passed to sqrt x was negative: ${x}"
         # TODO mul can exceed the precision needed so certain dot products get
         # weird
-        # x=$(abs $x)
+        # abs "$x"; x=$ret
         # echo 0
         # return
     fi
 
-    local guess=$(div_by_2 $x)
-    for i in {0..5}
-    do
-        if [ $guess -eq 0 ]
-        then
-            guess=0
-            break
+    div_by_2 "$x"
+    local guess=$ret
+    for i in {0..5}; do
+        if ((guess==0)); then
+          break
         fi
-
-        local tmp=$(div $x $guess)
-        tmp=$(add $tmp $guess)
-        guess=$(div_by_2 $tmp)
+        div "$x" "$guess"
+        add "$ret" "$guess"
+        div_by_2 "$ret"
+        guess=$ret
     done
-    echo $guess
+    ret=$guess
 }
 
 # Convert a number to fixed point representation
@@ -122,7 +77,7 @@ to_fp() {
         res=$(( int_part * scale + frac_padded ))
     fi
 
-    echo $res
+    ret=$res
 }
 
 # Converts from fixed point to normal representation
@@ -145,55 +100,46 @@ from_fp() {
     local x_length=${#x}
     local decimal_point_pos=$((x_length - frac_digits + 1))
     local fract_part=${x:$decimal_point_pos:$frac_digits}
-    echo "${int_part}.${fract_part}"
+    ret=${int_part}.${fract_part}
 }
 
 vec3_print() {
-    local v=("${!1}")
-    echo "{ $(from_fp ${v[0]}), $(from_fp ${v[1]}), $(from_fp ${v[2]}) }"
+    local -a v=("${!1}")
+    from_fp "${v[0]}"; v[0]=$ret
+    from_fp "${v[1]}"; v[1]=$ret
+    from_fp "${v[2]}"; v[2]=$ret
+    echo "{ ${v[0]}, ${v[1]}, ${v[2]} }"
 }
 
 print() {
-    from_fp $1
+    local ret
+    from_fp "$1"
+    echo "$1"
 }
 
-three_halves=$(to_fp 1.5)
+to_fp 1.5; three_halves=$ret
 
 inv_sqrt() {
-    local x=$1
-    div $scale $(sqrt $x)
-    # if [ "$x" -lt 0 ]
-    # then
+    sqrt "$1"
+    div "$scale" "$ret"
+
+    # if ((x<0)); then
     #     fatal "arg passed to inv sqrt x was negative ${x}"
     # fi
-
-    # local x2=$(div_by_2 $x)
-    # local guess=$(div $scale $x)
-
-    # for i in {0..4}
-    # do
-    #     local tmp=$(mul $guess $guess)
-    #     tmp=$(mul $tmp $x2)
-    #     tmp=$(sub $three_halves $tmp)
-    #     guess=$(mul $tmp $guess)
+    # div_by_2 "$x"; local x2=$ret
+    # div $scale $x; local guess=$ret
+    # for i in {0..4}; do
+    #     mul $guess $guess
+    #     mul $ret $x2
+    #     sub $three_halves $ret
+    #     mul $ret $guess
+    #     guess=$ret
     # done
-
-    # echo $guess
+    # ret=$guess
 }
 
 clamp_0_1() {
-    local x=$1
-    if [ $x -gt $scale ]
-    then
-        echo $scale
-    else
-        if [ $x -lt 0 ]
-        then
-            echo 0
-        else
-            echo $x
-        fi
-    fi
+  ((ret = $1 > scale ? scale : $1 < 0 ? 0 : $1, 1))
 }
 
 source ./vec_math.sh

--- a/math.sh
+++ b/math.sh
@@ -2,22 +2,22 @@
 scale="100000000"
 frac_digits=${#scale}
 
-add() ((ret = $1 + $2, 1))
-sub() ((ret = $1 - $2, 1))
+add() ((ret = $1 + $2))
+sub() ((ret = $1 - $2))
 
 mul() {
-    ((ret = $1 * $2 / scale, 1))
+    ((ret = $1 * $2 / scale))
     if ((ret < 0 && $1 > 0 && $2 > 0)); then
       log "OVERFLOW DETECTED: $1 x $2 = $ret"
     fi
 }
-div() ((ret = $1 * scale / $2, 1))
+div() ((ret = $1 * scale / $2))
 
-div_by_2() ((ret = $1 >> 1, 1))
-mul_by_2() ((ret = $1 << 1, 1))
+div_by_2() ((ret = $1 >> 1))
+mul_by_2() ((ret = $1 << 1))
 
-truncate() ((ret = $1 / scale, 1))
-abs() ((ret = $1 < 0 ? -$1 : $1, 1))
+truncate() ((ret = $1 / scale))
+abs() ((ret = $1 < 0 ? -$1 : $1))
 sqrt() {
     local x=$1
     if ((x < 0)); then
@@ -139,7 +139,7 @@ inv_sqrt() {
 }
 
 clamp_0_1() {
-  ((ret = $1 > scale ? scale : $1 < 0 ? 0 : $1, 1))
+  ((ret = $1 > scale ? scale : $1 < 0 ? 0 : $1))
 }
 
 source ./vec_math.sh

--- a/raytracer.sh
+++ b/raytracer.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -f
 
 source ./utils.sh
 source ./math.sh

--- a/raytracer.sh
+++ b/raytracer.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 set -f
 
 source ./utils.sh

--- a/raytracer.sh
+++ b/raytracer.sh
@@ -13,20 +13,20 @@ then
     fatal "Usage: ./raytracer.sh output.ppm"
 fi
 
-rgb_scaling=$(to_fp 255.99)
-half=$(to_fp 0.5)
-image_width_fp=$(to_fp ${IMAGE_WIDTH})
-image_height_fp=$(to_fp ${IMAGE_HEIGHT})
-ray_epsilon=$(to_fp 0.01)
+to_fp 255.99; rgb_scaling=$ret
+to_fp 0.5; half=$ret
+to_fp ${IMAGE_WIDTH}; image_width_fp=$ret
+to_fp ${IMAGE_HEIGHT}; image_height_fp=$ret
+to_fp 0.01; ray_epsilon=$ret
 
-sphere_radius=$(to_fp 2)
+to_fp 2; sphere_radius=$ret
 vec3_to_fp sphere_center 0.0 0.0 3.0
 vec3_to_fp sphere_color 0.3 0.3 0.3
 
-shadow_center=$(to_fp 3.75)
-shadow_radius=$(to_fp 5.5)
+to_fp 3.75; shadow_center=$ret
+to_fp 5.5; shadow_radius=$ret
 
-plane_y=$(to_fp -2)
+to_fp -2; plane_y=$ret
 vec3_to_fp plane_color_1 0.6 0.6 0.6
 vec3_to_fp plane_color_2 0.1 0.1 0.1
 
@@ -65,26 +65,26 @@ sphere_intersect() {
     local ray_dir=("${!5}")
 
     vec3_sub oc ray_origin[@] sphere_center[@]
-    local a=$(vec3_dot ray_dir[@] ray_dir[@])
-    local half_b=$(vec3_dot oc[@] ray_dir[@])
-    local oc_2=$(vec3_dot oc[@] oc[@])
+    local ret
+    vec3_dot ray_dir[@] ray_dir[@]; local a=$ret
+    vec3_dot oc[@] ray_dir[@]; local half_b=$ret
+    vec3_dot oc[@] oc[@]; local oc_2=$ret
 
-    local radius_2=$(mul $sphere_radius $sphere_radius)
-    local c=$(sub $oc_2 $radius_2)
+    mul "$sphere_radius" "$sphere_radius"; local radius_2=$ret
+    sub "$oc_2" "$radius_2"; local c=$ret
 
-    local half_b_2=$(mul $half_b $half_b)
-    local ac=$(mul $a $c)
-    local discrim=$(sub $half_b_2 $ac)
+    mul "$half_b" "$half_b"; local half_b_2=$ret
+    mul "$a" "$c"; local ac=$ret
+    sub "$half_b_2" "$ac"; local discrim=$ret
 
     if [ "$discrim" -gt 0 ]
     then
-        local root=$(sqrt $discrim)
-        local minus_half_b=$(sub 0 $half_b)
+        sqrt "$discrim"; local root=$ret
+        sub 0 "$half_b"; local minus_half_b=$ret
 
-        local t=$(sub $minus_half_b $root)
-        t=$(div $t $a)
-        if [ $t -gt 0 ]
-        then
+        sub "$minus_half_b" "$root"
+        div "$ret" "$a"; local t=$ret
+        if ((t > 0)); then
             # p = o + t * d
             vec3_mulf tv ray_dir[@] $t
             vec3_add point ray_origin[@] tv[@]
@@ -97,8 +97,9 @@ sphere_intersect() {
             return
         fi
 
-        t=$(add $minus_half_b $root)
-        t=$(div $t $a)
+        add "$minus_half_b" "$root"
+        div "$ret" "$a"
+        t=$ret
         if [ $t -gt 0 ]
         then
             # TODO is this branch the same as above? could refactor later
@@ -132,9 +133,11 @@ plane_intersect() {
         eval $hit_t_out=-1
     else
         # t = (c - o.y) / d.y
-        local ray_y_dist=$(sub $plane_y $ray_o_y)
+        local ret
+        sub "$plane_y" "$ray_o_y"; local ray_y_dist=$ret
         local ray_d_y=${ray_dir[1]}
-        local t=$(div $ray_y_dist $ray_d_y)
+        div "$ray_y_dist" "$ray_d_y"
+        local t=$ret
         if [ $t -gt 0 ] && [ $t -lt 2000000000 ]
         then
             vec3_mulf ray_scaled_d ray_dir[@] $t
@@ -151,8 +154,8 @@ plane_intersect() {
 
 # Takes out_origin as out_param 1
 offset_origin() {
-    local ray_origin=("${!2}")
-    local hit_norm=("${!3}")
+    local -a ray_origin=("${!2}")
+    local -a hit_norm=("${!3}")
     vec3_mulf scaled_norm hit_norm[@] $ray_epsilon
     vec3_add origin scaled_norm[@] ray_origin[@]
     vec3 $1 ${origin[@]}
@@ -161,20 +164,21 @@ offset_origin() {
 # doesn' account for shadowing, this is faked
 # Takes out_col as out_param 1
 light_contrib() {
-    local point=("${!2}")
-    local norm=("${!3}")
-    local light_pos=("${!4}")
-    local light_col=("${!5}")
+    local -a point=("${!2}")
+    local -a norm=("${!3}")
+    local -a light_pos=("${!4}")
+    local -a light_col=("${!5}")
     vec3_sub l light_pos[@] point[@]
     vec3_normalize lnorm l[@]
-    local ndotl=$(vec3_dot norm[@] lnorm[@])
+    local ret
+    vec3_dot norm[@] lnorm[@]; local ndotl=$ret
 
     if [ "$ndotl" -lt 0 ]
     then
         vec3 $1 0 0 0
     else
         vec3_mulf unscaled_out light_col[@] $ndotl
-        local l2=$(vec3_dot l[@] l[@])
+        vec3_dot l[@] l[@]; local l2=$ret
         vec3_divf $1 unscaled_out[@] $l2
     fi
 }
@@ -227,8 +231,9 @@ trace() {
         offset_origin new_origin hit_point_1[@] hit_normal_1[@]
 
         # reflect
-        local scalar=$(vec3_dot hit_normal_1[@] ray_dir[@])
-        scalar=$(mul_by_2 $scalar)
+        local ret
+        vec3_dot hit_normal_1[@] ray_dir[@]
+        mul_by_2 "$ret"; local scalar=$ret
         vec3_mulf refl_a hit_normal_1[@] $scalar
         vec3_sub new_dir ray_dir[@] refl_a[@]
 
@@ -259,10 +264,11 @@ trace() {
             local hit_p_z=${hit_point_2[2]}
 
             # Use equation of a circle to fake shadow
-            local shadow_offset_z=$(sub $hit_p_z $shadow_center)
-            local shadow_offset_x_2=$(mul $hit_p_x $hit_p_x)
-            local shadow_offset_z_2=$(mul $shadow_offset_z $shadow_offset_z)
-            local hit_dist_2=$(add $shadow_offset_x_2 $shadow_offset_z_2)
+            local ret
+            sub "$hit_p_z" "$shadow_center"; local shadow_offset_z=$ret
+            mul "$hit_p_x" "$hit_p_x"; local shadow_offset_x_2=$ret
+            mul "$shadow_offset_z" "$shadow_offset_z"; local shadow_offset_z_2=$ret
+            add "$shadow_offset_x_2" "$shadow_offset_z_2"; local hit_dist_2=$ret
 
             if [ $hit_dist_2 -gt $shadow_radius ]
             then
@@ -291,11 +297,12 @@ trace() {
             # shitty hack
             if [ $hit_p_x -lt 0 ]
             then
-                hit_p_x=$(add $hit_p_x $scale)
+              add "$hit_p_x" "$scale"; hit_p_x=$ret
             fi
 
-            hit_p_x=$(abs $hit_p_x)
-            hit_p_z=$(abs $hit_p_z)
+            local ret
+            abs "$hit_p_x"; hit_p_x=$ret
+            abs "$hit_p_z"; hit_p_z=$ret
 
             local base_col=(0 0 0)
             if [ $hit_p_x -gt $half ] && [ $hit_p_z -gt $half ]
@@ -337,29 +344,30 @@ worker() {
     local image_max_y=$(( WORKER_INDEX * IMAGE_HEIGHT / NUM_PROCS ))
     local image_max_x=$(( IMAGE_WIDTH ))
 
+    local ret rgb ray_dir o
     log "min_y ${image_min_y}, max_y: ${image_max_y}, max_x: ${image_max_x}"
     for ((y=${image_min_y};y<${image_max_y};y++)); do
-        local y_fp=$(to_fp $y)
-        local v=$(div $y_fp $image_height_fp)
+        to_fp "$y"; local y_fp=$ret
+        div "$y_fp" "$image_height_fp"; local v=$ret
 
-        local v2=$(mul_by_2 $v)
-        local ray_dir_y=$(sub $scale $v2)
+        mul_by_2 "$v"; local v2=$ret
+        sub "$scale" "$v2"; local ray_dir_y=$ret
 
         log "============ Processing ${y}/${image_max_y} ================"
         for ((x=0;x<${image_max_x};x++)); do
             # log "========= Processing ${y}/${image_max_y} ${x}/${image_max_x}"
-            local x_fp=$(to_fp $x)
-            local rgb=(0 0 0)
+            to_fp "$x"; local x_fp=$ret
+            rgb=(0 0 0)
 
-            local u=$(div $x_fp $image_width_fp)
+            div "$x_fp" "$image_width_fp"; local u=$ret
 
-            local u2=$(mul_by_2 $u)
-            local ray_dir_x=$(sub $u2 $scale)
+            mul_by_2 "$u"; local u2=$ret
+            sub "$u2" "$scale"; local ray_dir_x=$ret
 
-            local ray_dir=($ray_dir_x $ray_dir_y $scale)
+            ray_dir=($ray_dir_x $ray_dir_y $scale)
             vec3_normalize d ray_dir[@]
 
-            local o=(0 0 0)
+            o=(0 0 0)
             trace rgb o[@] d[@] 0
 
             # vec3_print rgb[@]

--- a/vec_math.sh
+++ b/vec_math.sh
@@ -69,7 +69,7 @@ vec3_dot() {
     mul ${a[0]} ${b[0]}; local x=$ret
     mul ${a[1]} ${b[1]}; local y=$ret
     mul ${a[2]} ${b[2]}; local z=$ret
-    ((ret = x + y + z, 1))
+    ((ret = x + y + z))
 }
 
 vec3_truncate() {

--- a/vec_math.sh
+++ b/vec_math.sh
@@ -1,119 +1,129 @@
 vec3() {
-    local __target=$1
-    eval $__target="($2 $3 $4)"
+    eval "$1=($2 $3 $4)"
 }
 
 vec3_add() {
-    local a=("${!2}")
-    local b=("${!3}")
+    local -a a=("${!2}")
+    local -a b=("${!3}")
 
-    local x=$(add ${a[0]} ${b[0]})
-    local y=$(add ${a[1]} ${b[1]})
-    local z=$(add ${a[2]} ${b[2]})
+    local ret
+    add ${a[0]} ${b[0]}; local x=$ret
+    add ${a[1]} ${b[1]}; local y=$ret
+    add ${a[2]} ${b[2]}; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 vec3_sub() {
-    local a=("${!2}")
-    local b=("${!3}")
+    local -a a=("${!2}")
+    local -a b=("${!3}")
 
-    local x=$(sub ${a[0]} ${b[0]})
-    local y=$(sub ${a[1]} ${b[1]})
-    local z=$(sub ${a[2]} ${b[2]})
+    local ret
+    sub ${a[0]} ${b[0]}; local x=$ret
+    sub ${a[1]} ${b[1]}; local y=$ret
+    sub ${a[2]} ${b[2]}; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 
 vec3_mul() {
-    local a=("${!2}")
-    local b=("${!3}")
+    local -a a=("${!2}")
+    local -a b=("${!3}")
 
-    local x=$(mul ${a[0]} ${b[0]})
-    local y=$(mul ${a[1]} ${b[1]})
-    local z=$(mul ${a[2]} ${b[2]})
+    local ret
+    mul ${a[0]} ${b[0]}; local x=$ret
+    mul ${a[1]} ${b[1]}; local y=$ret
+    mul ${a[2]} ${b[2]}; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 vec3_mulf() {
-    local a=("${!2}")
+    local -a a=("${!2}")
     local f=$3
 
-    local x=$(mul ${a[0]} $f)
-    local y=$(mul ${a[1]} $f)
-    local z=$(mul ${a[2]} $f)
+    local ret
+    mul ${a[0]} $f; local x=$ret
+    mul ${a[1]} $f; local y=$ret
+    mul ${a[2]} $f; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 vec3_divf() {
-    local a=("${!2}")
+    local -a a=("${!2}")
     local f=$3
 
-    local x=$(div ${a[0]} $f)
-    local y=$(div ${a[1]} $f)
-    local z=$(div ${a[2]} $f)
+    local ret
+    div ${a[0]} $f; local x=$ret
+    div ${a[1]} $f; local y=$ret
+    div ${a[2]} $f; local z=$ret
 
-    vec3 $1 $x $y $z
+    vec3 "$1" "$x" "$y" "$z"
 }
 
 vec3_dot() {
-    local a=("${!1}")
-    local b=("${!2}")
-
-    local x=$(mul ${a[0]} ${b[0]})
-    local y=$(mul ${a[1]} ${b[1]})
-    local z=$(mul ${a[2]} ${b[2]})
-
-    echo $((x + y + z))
+    local -a a=("${!1}")
+    local -a b=("${!2}")
+    mul ${a[0]} ${b[0]}; local x=$ret
+    mul ${a[1]} ${b[1]}; local y=$ret
+    mul ${a[2]} ${b[2]}; local z=$ret
+    ((ret = x + y + z, 1))
 }
 
 vec3_truncate() {
-    local a=("${!2}")
+    local -a a=("${!2}")
 
-    local x=$(truncate ${a[0]})
-    local y=$(truncate ${a[1]})
-    local z=$(truncate ${a[2]})
+    local ret
+    truncate ${a[0]}; local x=$ret
+    truncate ${a[1]}; local y=$ret
+    truncate ${a[2]}; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 vec3_sqrt() {
-    local a=("${!2}")
+    local -a a=("${!2}")
 
-    local x=$(sqrt ${a[0]})
-    local y=$(sqrt ${a[1]})
-    local z=$(sqrt ${a[2]})
+    local ret
+    sqrt ${a[0]}; local x=$ret
+    sqrt ${a[1]}; local y=$ret
+    sqrt ${a[2]}; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 vec3_normalize() {
-    local vec=("${!2}")
-    local vec_2=$(vec3_dot vec[@] vec[@])
-    local inv_length=$(inv_sqrt $vec_2)
+    local -a vec=("${!2}")
+    local ret
+    vec3_dot 'vec[@]' 'vec[@]'; local vec_2=$ret
+    inv_sqrt $vec_2; local inv_length=$ret
     vec3_mulf $1 vec[@] $inv_length
 }
 
 vec3_to_fp() {
-    vec3 $1 $(to_fp $2) $(to_fp $3) $(to_fp $4)
+    local ret
+    to_fp $2; local x=$ret
+    to_fp $3; local y=$ret
+    to_fp $4; local z=$ret
+    vec3 $1 $x $y $z
 }
 
 vec3_clamp_0_1() {
-    local a=("${!2}")
+    local -a a=("${!2}")
 
-    local x=$(clamp_0_1 ${a[0]})
-    local y=$(clamp_0_1 ${a[1]})
-    local z=$(clamp_0_1 ${a[2]})
+    local ret
+    clamp_0_1 ${a[0]}; local x=$ret
+    clamp_0_1 ${a[1]}; local y=$ret
+    clamp_0_1 ${a[2]}; local z=$ret
 
     vec3 $1 $x $y $z
 }
 
 vec3_test() {
-    local x=(2 -2 3)
-    local y=(-2 2 -3)
+    local -a x=(2 -2 3)
+    local -a y=(-2 2 -3)
     # vec3_clamp_0_1 res x[@]
     # echo ${res[@]}
 


### PR DESCRIPTION
Hi! I was very much interested in this project, and I find that we can improve the performance. Here I submit a PR. Now it runs 30 times faster than before (at least in my environment).
- e191333 The major bottleneck was the fork cost of the command substitutions `$(...)`. Each command substitution creates one process, so a process was created for each arithmetic operation such as `$(mul X Y)`. Instead of printing the calcualtion result to `stdout`, we can actually assign the result to a variable utilizing the Bash nature of dynamic scoping.
- 49c19cb In this script, we do not use the pathname expansions (aka globbing), so we can turn of them by `set -f`. This gives a slight improvement in the performance.
- 3da99ce The conditional command `[[ ... ]]` and arithmetic command `(( ... ))` are slightly faster than the builtin command `[`.
- 1b880c1 Since we want to extensively use `(( ... ))`, we may want to turn off `errexit` (`set -e`) so that we don't need a workaround of `((expr, 1))`. If you don't like this change, I can drop it from the PR.

Now we can generate the 512x512 image in several minutes.

```
# 64x64 (nproc 8)

real    0m4.582s
user    0m27.593s
sys     0m0.155s

# 512x512 (nproc 8)

real    4m50.742s
user    29m44.613s
sys     0m8.509s
```

I feel further improvements can be made by changing the interface of `vec_*`, but I stop here since I don't think it will change the time drastically.